### PR TITLE
Modified tmux.conf to support deprecations from tmux 2.0 per https://…

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -3,11 +3,8 @@
 
 # enable mouse click to select a pane
 #----------------------------------------
-setw -g mode-mouse on
-setw -g mouse-resize-pane on
-setw -g mouse-select-pane on
-setw -g mouse-select-window on
-setw -g mouse-utf8 on
+
+set -g mouse on
 #----------------------------------------
 #POST_2.1
 #----------------------------------------
@@ -39,7 +36,6 @@ bind -t vi-copy y copy-selection
 bind -t vi-copy V rectangle-toggle
 bind ] paste-buffer
 
-setw -g utf8 on
 
 # sync panes
 bind e setw synchronize-panes on


### PR DESCRIPTION
Version 2.0 of tmux removed the following mouse options:

	- mouse-resize-pane
	- mouse-select-pane
	- mouse-select-window
	- mode-mouse

Also, the following were removed:
         - mouse-utf8
         - utf8

These are incompatible changes, so you'll need to upgrade tmux for the new mouse option to work. 